### PR TITLE
gofer 2.x compat.

### DIFF
--- a/etc/gofer/plugins/katelloplugin.conf
+++ b/etc/gofer/plugins/katelloplugin.conf
@@ -1,3 +1,48 @@
+#
+# [main]
+#
+#   enabled
+#      Plugin enabled/disabled (0|1)
+#   name
+#      The (optional) plugin name. The basename of the descriptor is used when not specified.
+#   plugin
+#      The (optional) fully qualified module to be loaded from the PYTHON path.
+#   requires
+#      Specify (optional) required (,) comma separated list of plugins by name.
+#   extends
+#      Specify (optional) another plugin to extend by name.
+#
+# [messaging]
+#
+#   uuid
+#      The (optional) agent identity. This value also specifies the queue name.
+#   url
+#      The (optional) broker connection URL.
+#   cacert
+#      The (optional) SSL CA certificate used to validate the server certificate.
+#   clientcert
+#      The (optional) SSL client certificate.  PEM encoded and contains both key and certificate.
+#   host_validation
+#      The (optional) flag indicates SSL host validation should be performed.
+#   threads
+#      The (optional) number of threads for the RMI dispatcher.
+#
+# [model]
+#
+#   managed
+#      The (optional) level of broker model management.  Default: 2.
+#        - 0 = none
+#        - 1 = declare and bind queue.
+#        - 2 = declare and bind queue; drain and delete queue on explicit detach.
+#   queue
+#      The (optional) AMQP queue name.  This overrides the uuid.
+#   expiration
+#      The (optional) auto-deleted queue expiration (seconds).
+#   exchange
+#      The (optional) AMQP exchange.
+#
+#
+
 [main]
 enabled=1
 

--- a/katello-agent.spec
+++ b/katello-agent.spec
@@ -11,8 +11,8 @@ BuildArch: noarch
 BuildRequires: python2-devel
 BuildRequires: python-setuptools
 BuildRequires: rpm-python
-Requires: gofer >= 1.0.12
-Requires: python-gofer-qpid >= 1.0.12
+Requires: gofer >= 2.4
+Requires: python-gofer-qpid >= 2.4
 Requires: python-pulp-agent-lib >= 2.4.0
 Requires: pulp-rpm-handlers >= 2.4.0
 Requires: subscription-manager

--- a/src/katello/agent/katelloplugin.py
+++ b/src/katello/agent/katelloplugin.py
@@ -114,12 +114,11 @@ def setup_plugin():
     if not ConsumerIdentity.existsAndValid():
         # not registered
         return
-    cfg = plugin.cfg()
     rhsm_conf = Config(RHSM_CONFIG_PATH)
     certificate = ConsumerIdentity.read()
-    cfg.messaging.cacert = rhsm_conf['rhsm']['repo_ca_cert'] % rhsm_conf['rhsm']
-    cfg.messaging.url = 'ssl://%s:5671' % rhsm_conf['server']['hostname']
-    cfg.messaging.uuid = 'pulp.agent.%s' % certificate.getConsumerId()
+    plugin.cfg.messaging.cacert = rhsm_conf['rhsm']['repo_ca_cert'] % rhsm_conf['rhsm']
+    plugin.cfg.messaging.url = 'amqps://%s' % rhsm_conf['server']['hostname']
+    plugin.cfg.messaging.uuid = 'pulp.agent.%s' % certificate.getConsumerId()
     bundle(certificate)
 
 

--- a/test/test_plugin.py
+++ b/test/test_plugin.py
@@ -37,7 +37,7 @@ class PluginTest(TestCase):
         plugin_cfg = Mock()
         plugin_cfg.messaging = Mock()
         plugin.plugin = Mock()
-        plugin.plugin.cfg.return_value = plugin_cfg
+        plugin.plugin.cfg = plugin_cfg
         plugin.path_monitor = Mock()
         return plugin
 
@@ -184,9 +184,9 @@ class TestSetupPlugin(PluginTest):
         fake_valid.assert_called_with()
         fake_read.assert_called_with()
         fake_bundle.assert_called_with(fake_certificate)
-        plugin_cfg = self.plugin.plugin.cfg()
+        plugin_cfg = self.plugin.plugin.cfg
         self.assertEqual(plugin_cfg.messaging.cacert, '/etc/rhsm/ca/katello-server-ca.pem')
-        self.assertEqual(plugin_cfg.messaging.url, 'ssl://%s:5671' % host)
+        self.assertEqual(plugin_cfg.messaging.url, 'amqps://%s' % host)
         self.assertEqual(plugin_cfg.messaging.uuid, 'pulp.agent.%s' % consumer_id)
 
     @patch('katello.agent.katelloplugin.bundle')


### PR DESCRIPTION
Pulp 2.6 requires gofer 2.4.  The major version change of gofer requires the server and agent be on the same version.  gofer 2.4 is included in f21 on.

The *Plugin.cfg()* method changed to a property in gofer 2.

Better URL support in gofer 2 so amqps://<host> will default to the standard port for amqp ssl.