### PR TITLE
fixes #9403 - use correct certificate location

### DIFF
--- a/etc/gofer/plugins/katelloplugin.conf
+++ b/etc/gofer/plugins/katelloplugin.conf
@@ -4,5 +4,5 @@ enabled=1
 [messaging]
 url=
 uuid=
-cacert=/etc/rhsm/ca/candlepin-local.pem
+cacert=/etc/rhsm/ca/katello-server-ca.pem
 clientcert=/etc/pki/consumer/bundle.pem


### PR DESCRIPTION
Although, this needs some very obvious note in the upgrade docs for 2.1.1 to users that they need to regenerate their certificate RPM's as well in the upgrade case.

Renaming certificate locations is bad, especially when tools like katello-agent are relying on their location... :-1: 