### PR TITLE
Fixes #10670 - preffer the katello-default-ca.pem as the client ca cert

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+*.pyc
+test/data


### PR DESCRIPTION
Followed by candlepin-local.pem for backward compatibility and the
repo_ca_cert as fallback.

Requires https://github.com/Katello/puppet-certs/pull/62 to work properly.