### PR TITLE
Fixes #10670 - preffer the katello-default-ca.pem as the client ca cert

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+*.pyc
+test/data


### PR DESCRIPTION
Followed by candlepin-local.pem for backward compatibility and the repo_ca_cert as fallback.
(cherry picked from commit 2d7f81d679a595dc674b4a9c4e604b7e56c51262)