### PR TITLE
fixes #13957 - handle Consumer.unregister() call

### DIFF
--- a/src/katello/agent/katelloplugin.py
+++ b/src/katello/agent/katelloplugin.py
@@ -350,6 +350,14 @@ class UEP(UEPConnection):
 
 
 # --- API --------------------------------------------------------------------
+class Consumer(object):
+    """
+    When a consumer is unregistered, Katello notifies the goferd.
+    """
+
+    @remote
+    def unregister(self):
+        log.info('Consumer has been unregistered. Katello agent will no longer function until this system is reregistered.')
 
 
 class Content(object):

--- a/test/test_plugin.py
+++ b/test/test_plugin.py
@@ -541,6 +541,11 @@ class TestValidateRegistration(PluginTest):
         get_consumer.assert_called_with(consumer_id)
         self.assertFalse(self.plugin.registered)
 
+class TestConsumer(PluginTest):
+
+    def test_unregister(self):
+        consumer = self.plugin.Consumer()
+        consumer.unregister()
 
 class TestContent(PluginTest):
 


### PR DESCRIPTION
The consumer gets sent this unsupported `Consumer.unregister()` call which causes a nasty traceback (see below) when you run `subscription-manager unregister`

I thought it might be nice for goferd service to stop, but there doesn't seem a way for a plugin to tell the goferd to exit. And besides, if the user immediately re-registers then the goferd would be stopped and they might not want that.  So I log a message, to try to be helpful.  The logs look nicer, at least.  Any other suggestions maybe?

Before:

```
May 20 17:50:19 cloud-qe-7 goferd: [INFO][worker-0] gofer.rmi.dispatcher:600 - call: Consumer.unregister() sn=d38f07cc-ec0f-4424-b005-759d81d8871f data=None
May 20 17:50:19 cloud-qe-7 goferd: [ERROR][worker-0] gofer.rmi.dispatcher:636 - {u'replyto': None, u'request': {u'classname': u'Consumer', u'kws': {}, u'args': [], u'cntr': [[], {}], u'method': u'unregister'}, 'ts': 1432158618.611621, 'inbound': {'url': 'proton+amqps://ibm-x3250m4-05.lab.eng.rdu2.redhat.com:5647', 'queue': 'pulp.agent.2ef50b87-dfb2-4519-adcc-92c0dcf80e28'}, u'secret': u'555d0139361dd346181e3f16', u'version': u'2.0', u'routing': [None, u'pulp.agent.2ef50b87-dfb2-4519-adcc-92c0dcf80e28'], u'data': None, u'pam': None, u'sn': u'd38f07cc-ec0f-4424-b005-759d81d8871f'}
May 20 17:50:19 cloud-qe-7 goferd: [ERROR][worker-0] gofer.rmi.dispatcher:636 - Traceback (most recent call last):
May 20 17:50:19 cloud-qe-7 goferd: [ERROR][worker-0] gofer.rmi.dispatcher:636 - File "/usr/lib/python2.7/site-packages/gofer/rmi/dispatcher.py", line 632, in dispatch
May 20 17:50:19 cloud-qe-7 goferd: [ERROR][worker-0] gofer.rmi.dispatcher:636 - method = RMI
May 20 17:50:19 cloud-qe-7 goferd: [ERROR][worker-0] gofer.rmi.dispatcher:636 - File "/usr/lib/python2.7/site-packages/gofer/rmi/dispatcher.py", line 348, in init
May 20 17:50:19 cloud-qe-7 goferd: [ERROR][worker-0] gofer.rmi.dispatcher:636 - self.inst = self.find_class(request, catalog)
May 20 17:50:19 cloud-qe-7 goferd: [ERROR][worker-0] gofer.rmi.dispatcher:636 - File "/usr/lib/python2.7/site-packages/gofer/rmi/dispatcher.py", line 368, in find_class
May 20 17:50:19 cloud-qe-7 goferd: [ERROR][worker-0] gofer.rmi.dispatcher:636 - raise ClassNotFound(key)
May 20 17:50:19 cloud-qe-7 goferd: [ERROR][worker-0] gofer.rmi.dispatcher:636 - ClassNotFound: Consumer
```


After:

```
Feb 29 13:58:52 satellite goferd: [INFO][worker-0] gofer.rmi.dispatcher:600 - call: Consumer.unregister() sn=21a2337b-28fe-4af7-9764-13c610055b0f data=None
Feb 29 13:58:52 satellite goferd: [INFO][worker-0] katelloplugin:361 - Consumer has been unregistered. Katello agent will no longer function until this system is reregistered.
```
