### PR TITLE
Fixes #20702 - use optparse instead of argparse

### DIFF
--- a/bin/katello-enabled-repos-upload
+++ b/bin/katello-enabled-repos-upload
@@ -1,7 +1,7 @@
 #!/usr/bin/python
 
 import sys
-import argparse
+import optparse
 
 sys.path.append('/usr/lib/yum-plugins')
 
@@ -9,13 +9,13 @@ import enabled_repos_upload
 from enabled_repos_upload import EnabledRepoCache
 
 def parse_args():
-  parser = argparse.ArgumentParser()
-  parser.add_argument('-f', '--force', help="Force enabled repository upload even if it does not seem out of date.", action='store_true')
+  parser = optparse.OptionParser()
+  parser.add_option('-f', '--force', help="Force enabled repository upload even if it does not seem out of date.", action='store_true')
   return parser.parse_args()
 
 def main():
-    args = parse_args()
-    if args.force:
+    (options, args) = parse_args()
+    if options.force:
         EnabledRepoCache.remove_cache()
     enabled_repos_upload.upload_enabled_repos_report()
 

--- a/bin/katello-package-upload
+++ b/bin/katello-package-upload
@@ -14,20 +14,20 @@
 #
 
 import sys
-import argparse
+import optparse
 
 sys.path.append('/usr/lib/yum-plugins')
 import package_upload
 
 def parse_args():
-  parser = argparse.ArgumentParser()
-  parser.add_argument('-f', '--force', help="Force package upload even if it does not seem out of date.", action='store_true')
+  parser = optparse.OptionParser()
+  parser.add_option('-f', '--force', help="Force package upload even if it does not seem out of date.", action='store_true')
   return parser.parse_args()
 
 
 def main():
-    args = parse_args()
-    if args.force:
+    (options, args) = parse_args()
+    if options.force:
         package_upload.remove_cache()
     package_upload.upload_package_profile()
 


### PR DESCRIPTION
this makes the code compatible with Python < 2.7 (EL5: 2.4, EL6: 2.6)